### PR TITLE
Make getWidth compatible with css scale

### DIFF
--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -94,7 +94,10 @@ var helpers = {
     });
   },
   getWidth: function getWidth(elem) {
-    return elem.getBoundingClientRect().width || elem.offsetWidth || 0;
+    var scaleX = (elem.getBoundingClientRect().width / (elem.offsetWidth || 1)) || 1;
+    return (
+      1 / scaleX * (elem.getBoundingClientRect().width || elem.offsetWidth || 0)
+    );
   },
   getHeight(elem) {
     return elem.getBoundingClientRect().height || elem.offsetHeight || 0;


### PR DESCRIPTION
In order to have successful render when scaling the slideshow with something like {transform : scale(.5)} we need to calculate how much the element has scaled and put it into calculation when deciding a new width for element